### PR TITLE
Always offer completions (workaround for company issue #476)

### DIFF
--- a/company-math.el
+++ b/company-math.el
@@ -147,9 +147,13 @@ corresponding unicode symbol."
   (cl-case command
     (interactive (company-begin-backend 'company-math-symbols-unicode))
     (prefix (company-math--prefix company-math-allow-unicode-symbols-in-faces
-				  company-math-disallow-unicode-symbols-in-faces))
+                                  company-math-disallow-unicode-symbols-in-faces))
     (annotation (concat " " (get-text-property 0 :symbol arg)))
-    (candidates (all-completions arg company-math--symbols))
+    ;; Space added to ensure that completions are never typed in full.
+    ;; See https://github.com/company-mode/company-mode/issues/476
+    (candidates (mapcar (lambda (candidate)
+                          (concat candidate " "))
+                        (all-completions arg company-math--symbols)))
     (post-completion (company-math--substitute-unicode
 		      (get-text-property 0 :symbol arg)))))
 


### PR DESCRIPTION
The issue appears clearly when one wants to insert unicode symbols with
short LaTeX names, such as ‘\Cap’, ‘\wp’, or ‘\wr’. The problem is that
company-mode closes its popup if there is only one completion available,
and it has been typed in full. In that case, even running
‘company-manual-begin’ has no effect; the only way to insert the
corresponding unicode symbol is to remove the last character of the
symbol, and to run ‘company-manual-begin’.

This commit introduces the workaround discussed in
https://github.com/company-mode/company-mode/issues/476: we add a space
at the end of each symbol in ‘company-math-symbols-unicode’, to ensure
that the user can always use ‘RET’ to insert Unicode symbols.
