### PR TITLE
Enable latex backend in org-mode per default

### DIFF
--- a/company-math.el
+++ b/company-math.el
@@ -88,7 +88,7 @@ When set to special value t, allow on all faces except those in
   :type '(choice (const t)
                  (repeat :tag "Faces" symbol)))
 
-(defcustom company-math-allow-latex-symbols-in-faces '(tex-math font-latex-math-face)
+(defcustom company-math-allow-latex-symbols-in-faces '(tex-math font-latex-math-face org-latex-and-related)
   "List of faces to disallow the insertion of latex mathematical symbols.
 When set to special value t, allow on all faces except those in
 `company-math-disallow-latex-symbols-in-faces'."


### PR DESCRIPTION
Since org-mode uses latex syntax for formulars, this might be usefull. This was discussed in issue #14.